### PR TITLE
Relax version bounds on generic-lens dependency

### DIFF
--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -68,7 +68,7 @@ test-suite generic-lens
   main-is:             GenericLens.hs
   build-depends:       inspection-testing
   build-depends:       base >=4.9 && <4.12
-  build-depends:       generic-lens ==0.4.0.1
+  build-depends:       generic-lens >= 0.4.0.1 && <= 0.5.0.0
   default-language:    Haskell2010
   ghc-options:         -main-is GenericLens
 


### PR DESCRIPTION
The precise version in the `generic-lens` test means that that a newer version of `generic-lens` can't be built together with `inspection-testing`'s test suite.

(This caused an issue when I wanted to add my library to stackage https://github.com/fpco/stackage/pull/3021)