### PR TITLE
Add hasNoGenerics

### DIFF
--- a/Test/Inspection.hs
+++ b/Test/Inspection.hs
@@ -24,7 +24,7 @@ module Test.Inspection (
     Result(..),
     -- * Defining obligations
     Obligation(..), mkObligation, Property(..),
-    (===), (==-), (=/=), hasNoType,
+    (===), (==-), (=/=), hasNoType, hasNoGenerics,
 ) where
 
 import Language.Haskell.TH
@@ -34,6 +34,7 @@ import Language.Haskell.TH.Syntax (getQ, putQ) -- only for needsPluginQ
 #endif
 import Data.Data
 import GHC.Exts (lazy)
+import GHC.Generics (V1(), U1(), M1(), K1(), (:+:), (:*:))
 
 {- $synposis
 
@@ -101,7 +102,7 @@ data Property
     -- @f = e@ and @g = e@.
     --
     -- In general @f@ and @g@ need to be defined in this module, so that their
-    -- actual defintions can be inspected. 
+    -- actual defintions can be inspected.
     --
     -- If the boolean flag is true, then ignore types during the comparison.
     = EqualTo Name Bool
@@ -155,7 +156,13 @@ mkEquality expectFail ignore_types n1 n2 =
 hasNoType :: Name -> Name -> Obligation
 hasNoType n tn = mkObligation n (NoTypes [tn])
 
-
+-- | Convenience function to declare that a function’s implementation does not
+-- contain any generic constructors.
+--
+-- @inspect $ hasNoGenerics genericFunction@
+hasNoGenerics :: Name -> Obligation
+hasNoType n = mkObligation n
+                  (NoTypes [''V1, ''U1, ''M1, ''K1, ''(:+:), ''(:*:)])
 
 -- | Internal class that prevents compilation when the plugin is not loaded
 class PluginNotLoaded

--- a/Test/Inspection.hs
+++ b/Test/Inspection.hs
@@ -34,7 +34,7 @@ import Language.Haskell.TH.Syntax (getQ, putQ) -- only for needsPluginQ
 #endif
 import Data.Data
 import GHC.Exts (lazy)
-import GHC.Generics (V1(), U1(), M1(), K1(), (:+:), (:*:))
+import GHC.Generics (V1(), U1(), M1(), K1(), (:+:), (:*:), (:.:), Rec1, Par1)
 
 {- $synposis
 
@@ -162,7 +162,10 @@ hasNoType n tn = mkObligation n (NoTypes [tn])
 -- @inspect $ hasNoGenerics genericFunction@
 hasNoGenerics :: Name -> Obligation
 hasNoGenerics n =
-    mkObligation n (NoTypes [''V1, ''U1, ''M1, ''K1, ''(:+:), ''(:*:)])
+    mkObligation n
+        (NoTypes [ ''V1, ''U1, ''M1, ''K1, ''(:+:), ''(:*:), ''(:.:), ''Rec1
+                 , ''Par1
+                 ])
 
 -- | Internal class that prevents compilation when the plugin is not loaded
 class PluginNotLoaded

--- a/Test/Inspection.hs
+++ b/Test/Inspection.hs
@@ -161,8 +161,8 @@ hasNoType n tn = mkObligation n (NoTypes [tn])
 --
 -- @inspect $ hasNoGenerics genericFunction@
 hasNoGenerics :: Name -> Obligation
-hasNoType n = mkObligation n
-                  (NoTypes [''V1, ''U1, ''M1, ''K1, ''(:+:), ''(:*:)])
+hasNoGenerics n =
+    mkObligation n (NoTypes [''V1, ''U1, ''M1, ''K1, ''(:+:), ''(:*:)])
 
 -- | Internal class that prevents compilation when the plugin is not loaded
 class PluginNotLoaded

--- a/examples/Generics.hs
+++ b/examples/Generics.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE RankNTypes, DeriveGeneric, TypeApplications, DataKinds, ExistentialQuantification, TemplateHaskell #-}
+{-# OPTIONS_GHC -O -fplugin Test.Inspection.Plugin #-}
+module Generics (main) where
+
+import GHC.Generics
+import Test.Inspection
+
+data Record = MkRecord
+  { fieldA :: Int
+  , fieldB :: Bool
+  } deriving Generic
+
+
+myRecord :: Record
+myRecord = MkRecord 1 True
+
+genericRep :: Rep Record x
+genericRep = from myRecord
+
+
+roundTripRep :: Record
+roundTripRep = to $ from myRecord
+
+main :: IO ()
+main = return ()
+
+-- the check
+inspect $ hasNoGenerics 'roundTripRep
+inspect $ (hasNoGenerics 'genericRep) { expectFail = True }
+

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -108,6 +108,18 @@ test-suite text
   default-language:    Haskell2010
   ghc-options:         -main-is Text
 
+test-suite generics
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      examples
+  main-is:             Generics.hs
+  if flag(more-tests)
+    build-depends:       inspection-testing
+    build-depends:       base >=4.9 && <4.13
+  else
+    buildable:         False
+  default-language:    Haskell2010
+  ghc-options:         -main-is Generics
+
 test-suite generic-lens
   type:                exitcode-stdio-1.0
   hs-source-dirs:      examples


### PR DESCRIPTION
Helper obligation to show that a function does not contain any generic constructors.