### PR TITLE
Sort binder groups so that order doesn't matter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for inspection-testing
 
+## 0.3.1 -- 2018-08-02
+
+* Recursive binder ordering no longer matters
+
 ## 0.3 -- 2018-07-07
 
 * On GHC-8.5 or newer, use of `inspect` or `inspectTest` without actually

--- a/examples/MutualRecursion.hs
+++ b/examples/MutualRecursion.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
+module MutualRecursion where
+
+import Test.Inspection
+
+inf = go0
+  where
+    go0 = 'a' : go1
+    go1 = 'b' : go2
+    go2 = 'c' : go0
+inf' = go0
+  where
+    go1 = 'b' : go2
+    go0 = 'a' : go1
+    go2 = 'c' : go0
+
+inspect $ 'inf === 'inf'
+
+main = pure ()

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -73,6 +73,15 @@ test-suite simple
   default-language:    Haskell2010
   ghc-options:         -main-is Simple
 
+test-suite mutual-recursion
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      examples
+  main-is:             MutualRecursion.hs
+  build-depends:       inspection-testing
+  build-depends:       base >=4.9 && <4.13
+  default-language:    Haskell2010
+  ghc-options:         -main-is MutualRecursion
+
 test-suite simple-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      examples

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -1,5 +1,5 @@
 name:                inspection-testing
-version:             0.3
+version:             0.3.1
 synopsis:            GHC plugin to do inspection testing
 description:         Some carefully crafted libraries make promises to their
                      users beyond functionality and performance.


### PR DESCRIPTION
This solves the simple case below but still breaks on examples where lexicographic ordering won't help, like in code generated by Template Haskell (which is where I discovered the issue). And it actually makes the problem impossible to solve in my real use-case, whereas using 0.3 I can make it work by twiddling the binder order in the `where` clause.

Can we actually solve this in the general case? Apparently `Ord` on `Var` is non-deterministic, so I can foresee it introducing some weird failures.

---
I was pulling my hair out over a 'failing' inspection test today when I realised that the plugin cared about binder ordering.

The minimal example (which is also included in this PR) is:

```
inf = go0
  where
    go0 = 'a' : go1
    go1 = 'b' : go2
    go2 = 'c' : go0
inf' = go0
  where
    go1 = 'b' : go2
    go0 = 'a' : go1
    go2 = 'c' : go0

 inspect $ 'inf === 'inf'
```

This test will fail when run with HEAD, but I really don't think that's okay.