### PR TITLE
Add "-main-is WorkerWrapper" GHC options

### DIFF
--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -191,5 +191,6 @@ test-suite worker-wrapper
   build-depends:       inspection-testing
   build-depends:       base >=4.9 && <4.15
   default-language:    Haskell2010
+  ghc-options:         -main-is WorkerWrapper
   if impl(ghc < 8.4)
       ghc-options:       -fplugin=Test.Inspection.Plugin


### PR DESCRIPTION
This stops the WorkerWrapper test exiting non-zero

Whoops, sorry about https://github.com/nomeata/inspection-testing/pull/42#issuecomment-605016795

I'm confused why need `-main-is` in the `ghc-options` when we already specify the `main-is` field, but need it we do. This should fix the CI