### PR TITLE
Ignores HPC ticks in `(==-)`

### DIFF
--- a/examples/HPCs.hs
+++ b/examples/HPCs.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -O -fhpc -fplugin-opt=Test.Inspection.Plugin:quiet #-}
+module HPCs (main) where
+
+import Test.Inspection
+
+main :: IO ()
+main = return ()
+
+theTwo :: Int
+theTwo = 2
+
+anotherTwo :: Int
+anotherTwo = 2
+
+theOnePlusOne :: Int
+theOnePlusOne = 1 + 1
+
+inspect $ 'theTwo ==- 'theOnePlusOne
+inspect $ 'theTwo ==- 'anotherTwo
+inspect $ 'theTwo =/= 'theOnePlusOne
+inspect $ 'theTwo =/= 'anotherTwo

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -65,6 +65,17 @@ test-suite NS_NP
   if impl(ghc < 8.4)
       ghc-options:       -fplugin=Test.Inspection.Plugin
 
+test-suite HPCs
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      examples
+  main-is:             HPCs.hs
+  build-depends:       inspection-testing
+  build-depends:       base >=4.9 && <4.15
+  default-language:    Haskell2010
+  ghc-options:         -main-is HPCs
+  if impl(ghc < 8.4)
+      ghc-options:       -fplugin=Test.Inspection.Plugin
+
 test-suite simple
   type:                exitcode-stdio-1.0
   hs-source-dirs:      examples

--- a/src/Test/Inspection.hs
+++ b/src/Test/Inspection.hs
@@ -114,7 +114,6 @@ data Property
     --
     -- If the boolean flag is true, then ignore types and hpc ticks
     -- during the comparison.
-    -- See the note of '==-' for the pitfalls with coverage test.
     = EqualTo Name Bool
 
     -- | Do none of these types appear anywhere in the definition of the function

--- a/src/Test/Inspection.hs
+++ b/src/Test/Inspection.hs
@@ -112,7 +112,8 @@ data Property
     -- In general @f@ and @g@ need to be defined in this module, so that their
     -- actual defintions can be inspected.
     --
-    -- If the boolean flag is true, then ignore types during the comparison.
+    -- If the boolean flag is true, then ignore types and hpc ticks
+    -- during the comparison.
     = EqualTo Name Bool
 
     -- | Do none of these types appear anywhere in the definition of the function
@@ -155,7 +156,7 @@ These convenience functions create common test obligations directly.
 infix 9 ===
 
 -- | Declare two functions to be equal, but ignoring
--- type lambdas, type arguments and type casts (see 'EqualTo')
+-- hpc ticks, type lambdas, type arguments and type casts (see 'EqualTo')
 (==-) :: Name -> Name -> Obligation
 (==-) = mkEquality False True
 infix 9 ==-

--- a/src/Test/Inspection.hs
+++ b/src/Test/Inspection.hs
@@ -156,12 +156,8 @@ These convenience functions create common test obligations directly.
 infix 9 ===
 
 -- | Declare two functions to be equal, but ignoring
--- hpc ticks, type lambdas, type arguments and type casts (see 'EqualTo').
---
--- Note: If the code being inspected contains if- or case-expression,
--- the generated Core can contain trivial branching, even with @-O2@ option.
--- To test the optimised code correctly, we recommend turning off @-fhpc@ option,
--- and testing against libraries compiled /without/ @-fhpc@ (or equivalent) option.
+-- type lambdas, type arguments, type casts and hpc ticks (see 'EqualTo').
+-- Note that `-fhpc` can prevent some optimizations; build without for more reliable analysis.
 (==-) :: Name -> Name -> Obligation
 (==-) = mkEquality False True
 infix 9 ==-

--- a/src/Test/Inspection.hs
+++ b/src/Test/Inspection.hs
@@ -114,6 +114,7 @@ data Property
     --
     -- If the boolean flag is true, then ignore types and hpc ticks
     -- during the comparison.
+    -- See the note of '==-' for the pitfalls with coverage test.
     = EqualTo Name Bool
 
     -- | Do none of these types appear anywhere in the definition of the function
@@ -156,7 +157,12 @@ These convenience functions create common test obligations directly.
 infix 9 ===
 
 -- | Declare two functions to be equal, but ignoring
--- hpc ticks, type lambdas, type arguments and type casts (see 'EqualTo')
+-- hpc ticks, type lambdas, type arguments and type casts (see 'EqualTo').
+--
+-- Note: If the code being inspected contains if- or case-expression,
+-- the generated Core can contain trivial branching, even with @-O2@ option.
+-- To test the optimised code correctly, we recommend turning off @-fhpc@ option,
+-- and testing against libraries compiled /without/ @-fhpc@ (or equivalent) option.
 (==-) :: Name -> Name -> Obligation
 (==-) = mkEquality False True
 infix 9 ==-

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -139,6 +139,7 @@ eqSlice it slice1 slice2
     essentiallyVar (Lam v e)  | it, isTyCoVar v = essentiallyVar e
     essentiallyVar (Cast e _) | it              = essentiallyVar e
     essentiallyVar (Var v)                      = Just v
+    essentiallyVar (Tick HpcTick{} e) | it      = essentiallyVar e
     essentiallyVar _                            = Nothing
 
     go :: RnEnv2 -> CoreExpr -> CoreExpr -> MaybeT (State (S.Set (Var,Var))) ()

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -98,7 +98,7 @@ type VarPairSet = S.Set VarPair
 -- have auxiliary variables in the right order.
 -- (This is mostly to work-around the buggy CSE in GHC-8.0)
 -- It also breaks if there is shadowing.
-eqSlice :: Bool {- ^ ignore types -} -> Slice -> Slice -> Bool
+eqSlice :: Bool {- ^ ignore types and hpc ticks -} -> Slice -> Slice -> Bool
 eqSlice _ slice1 slice2 | null slice1 || null slice2 = null slice1 == null slice2
   -- Mostly defensive programming (slices should not be empty)
 eqSlice it slice1 slice2
@@ -156,6 +156,8 @@ eqSlice it slice1 slice2
     go env (App e1 a) e2 | it, isTyCoArg a = go env e1 e2
     go env e1 (App e2 a) | it, isTyCoArg a = go env e1 e2
     go env (App f1 a1)   (App f2 a2)       = go env f1 f2 >> go env a1 a2
+    go env (Tick HpcTick{} e1) e2 | it     = go env e1 e2
+    go env e1 (Tick HpcTick{} e2) | it     = go env e1 e2
     go env (Tick n1 e1)  (Tick n2 e2)      = guard (go_tick env n1 n2) >> go env e1 e2
 
     go env (Lam b e1) e2 | it, isTyCoVar b = go env e1 e2


### PR DESCRIPTION
`-fhpc` flag generates extra `HPCTick` Tickish in the Core, which prevents using `inspection-testing` with Haskell Program Coverage tool.
This pull-request gently ignores `Tick HPCTick{}` when the "ignore" option in `mkEquality` is enabled.

This closes #47.