### PR TITLE
Add skip-O0 plugin option

### DIFF
--- a/src/Test/Inspection/Plugin.hs
+++ b/src/Test/Inspection/Plugin.hs
@@ -24,10 +24,17 @@ import Test.Inspection.Core
 
 -- | The plugin. It supports some options:
 --
--- * @-fplugin-opt=Test.Inspection.Plugin:keep-going@ to ignore a failing build
--- * @-fplugin-opt=Test.Inspection.Plugin:keep-going-O0@ to ignore a failing build when optimisations are off
--- * @-fplugin-opt=Test.Inspection.Plugin:skip-O0@ to skip inspections when optimisations are off
+-- * @-fplugin-opt=Test.Inspection.Plugin:keep-going@ to keep building despite failing obligations
+-- * @-fplugin-opt=Test.Inspection.Plugin:keep-going-O0@ to keep building despite failing obligations, when optimisations are off
+-- * @-fplugin-opt=Test.Inspection.Plugin:skip-O0@ to skip performing inspections when optimisations are off
 -- * @-fplugin-opt=Test.Inspection.Plugin:quiet@ to be silent if all obligations are fulfilled
+--
+-- It makes sense to enable only one of @keep-going@, @keep-going-O0@ and
+-- @skip-O0@ at a time. @skip-O0@ is useful when working with GHCi, to suppress
+-- inspection failure messages and eliminate the overhead of inspection when
+-- loading.
+
+
 plugin :: Plugin
 plugin = defaultPlugin
     { installCoreToDos = install


### PR DESCRIPTION
Background: I was trying to use inspection to check unboxing in [this file](https://github.com/AndrasKovacs/setoidtt/blob/fb9688475a777082ae7452aae0e4ce9c29351a1f/setoidtt/src/Eval.hs), which yields about 7000 lines of core with `-O2`, most of which is to be inspected. 

I've found that loading in ghci becomes unacceptably slow with inspection, goes from around 2 seconds to something which I don't have the patience to wait for. In contrast, compilation with `-O` and `-O2` is only about 10% slower with inspection.

A possible solution to my problem would be to put inspections in a different module than my definitions. However, I've found that `inspection-testing` can only follow referenced core definitions in the current module, so this doesn't work for me.

While this slowdown in interactive mode is probably worth to investigate, I think a very simple solution, which seems useful anyway, is to add a plugin option which disables inspection in the case of `-O0`. So that's what I did.