### PR TITLE
GHC 9 Workarounds (libraries only)

### DIFF
--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -45,8 +45,8 @@ library
                        Test.Inspection.Plugin
                        Test.Inspection.Core
   hs-source-dirs:      src
-  build-depends:       base >=4.9 && <4.15
-  build-depends:       ghc >= 8.0.2 && <8.11
+  build-depends:       base >=4.9 && <4.16
+  build-depends:       ghc >= 8.0.2 && <9.1
   build-depends:       template-haskell
   build-depends:       containers
   build-depends:       transformers

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -17,11 +17,11 @@ import GHC.Core
 import GHC.Core.Utils
 import GHC.Core.TyCo.Rep
 import GHC.Core.Type
-import GHC.Types.Var
+import GHC.Types.Var as Var
 import GHC.Types.Id
 import GHC.Types.Name
 import GHC.Types.Var.Env
-import GHC.Utils.Outputable
+import GHC.Utils.Outputable as Outputable
 import GHC.Core.Ppr
 import GHC.Core.Coercion
 import GHC.Utils.Misc

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -101,7 +101,7 @@ pprSliceDifference slice1 slice2 =
     slice2' = filter (\(v,_) -> v `S.notMember` both) slice2
 
 withLessDetail :: SDoc -> SDoc
-#if MIN_VERSION_GLASGOW_HASKELL(8,2,0,0)
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,0,0) && !MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 withLessDetail sdoc = sdocWithDynFlags $ \dflags ->
      withPprStyle (defaultUserStyle dflags) sdoc
 #else
@@ -259,6 +259,9 @@ allTyCons ignore slice =
     goT (ForAllTy _ t)   = goT t
 #if MIN_VERSION_GLASGOW_HASKELL(8,2,0,0)
     goT (FunTy
+#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
+               _
+#endif
 # if MIN_VERSION_GLASGOW_HASKELL(8,9,0,0)
                _
 # endif

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -12,6 +12,22 @@ module Test.Inspection.Core
   , doesNotContainTypeClasses
   ) where
 
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Core
+import GHC.Core.Utils
+import GHC.Core.TyCo.Rep
+import GHC.Core.Type
+import GHC.Types.Var
+import GHC.Types.Id
+import GHC.Types.Name
+import GHC.Types.Var.Env
+import GHC.Utils.Outputable
+import GHC.Core.Ppr
+import GHC.Core.Coercion
+import GHC.Utils.Misc
+import GHC.Core.DataCon
+import GHC.Core.TyCon (TyCon, isClassTyCon)
+#else
 import CoreSyn
 import CoreUtils
 import TyCoRep
@@ -26,6 +42,7 @@ import Coercion
 import Util
 import DataCon
 import TyCon (TyCon, isClassTyCon)
+#endif
 
 import qualified Data.Set as S
 import Control.Monad.State.Strict

--- a/src/Test/Inspection/Plugin.hs
+++ b/src/Test/Inspection/Plugin.hs
@@ -16,8 +16,13 @@ import Data.List
 import qualified Data.Map.Strict as M
 import qualified Language.Haskell.TH.Syntax as TH
 
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Plugins hiding (SrcLoc)
+import GHC.Utils.Outputable as Outputable
+#else
 import GhcPlugins hiding (SrcLoc)
 import Outputable
+#endif
 
 import Test.Inspection (Obligation(..), Property(..), Result(..))
 import Test.Inspection.Core


### PR DESCRIPTION
In GHC 9, module hierarchy of `ghc` the library changes drastically, and `FunTy` has an extra argument.
This pull-request addresses these changes and compiles with GHC 9.0.1-RC1.
Since I cannot tell how to use release candidate with the existing GitHub Workflow, so I built and ran tests by hand, using the following stack.yaml:

```yaml
resolver: nightly-2021-01-17
compiler: ghc-9.0.0.20201227
compiler-check: match-exact
setup-info:
 ghc:
  linux64:
   9.0.0.20201227:
    url: https://downloads.haskell.org/ghc/9.0.1-rc1/ghc-9.0.0.20201227-x86_64-deb9-linux.tar.xz
    sha256: 53f1d9b1cd7cbac4f4e683b5bcf2d08dd45852bd55218c7c5e965b5a78704f15

  macosx:
   9.0.0.20201227:
    url: https://downloads.haskell.org/ghc/9.0.1-rc1/ghc-9.0.0.20201227-x86_64-apple-darwin.tar.xz
    sha256: e6e5bf34c002d52d7108b9d4c8621ae3d21059509f8868bb81b0ba4fda6320da

allow-newer: true

flags: {}
packages:
- .
```

It turns out that basic tests pass except for `fusion`:

<details>
<summary>Error log of fusion</summary>

```
$ stack test --stack-yaml=stack-9.0.1.yaml inspection-testing:test:fusion
Stack has not been tested with GHC versions above 8.10, and using 9.0.0.20201227, this may fail
Stack has not been tested with Cabal versions above 3.2, but version 3.4.0.0 was found, this may fail
inspection-testing-0.4.2.4: unregistering (components added: test:fusion)
inspection-testing> configure (lib + test)
Configuring inspection-testing-0.4.2.4...
inspection-testing> build (lib + test)
Preprocessing library for inspection-testing-0.4.2.4..
Building library for inspection-testing-0.4.2.4..
Preprocessing test suite 'fusion' for inspection-testing-0.4.2.4..
Building test suite 'fusion' for inspection-testing-0.4.2.4..
[1 of 1] Compiling Fusion
/Users/hiromi/Documents/Programming/Haskell/git/inspection-testing/examples/Fusion.hs:21:1: sumUp1 === sumUp2 failed:
    LHS:    
        sumUp1 :: Int -> Bool
        [LclIdX,
         Arity=1,
         Str=<S,1*U(U)>,
         Unf=Unf{Src=InlineStable, TopLvl=True, Value=True, ConLike=True,
                 WorkFree=True, Expandable=True,
                 Guidance=ALWAYS_IF(arity=1,unsat_ok=True,boring_ok=False)
                 Tmpl= \ (n [Occ=Once1!] :: Int) ->
                         case n of { I# y ->
                         case ># 1# y of {
                           __DEFAULT ->
                             joinrec {
                               go9 [Occ=LoopBreakerT[2]] :: Int# -> Int -> Bool
                               [LclId[JoinId(2)],
                                Arity=2,
                                Str=<L,U><L,U>,
                                Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True,
                                        WorkFree=True, Expandable=True,
                                        Guidance=IF_ARGS [0 40] 62 0}]
                               go9 (x :: Int#) (v [Occ=Once2!, OS=OneShot] :: Int)
                                 = case ==# x y of {
                                     __DEFAULT ->
                                       jump go9
                                         (+# x 1#) (case v of { I# x [Occ=Once1] -> I# (+# x x) });
                                     1# ->
                                       case v of { I# x [Occ=Once1] ->
                                       tagToEnum# @Bool (># (+# x x) 1000#)
                                       }
                                   }; } in
                             jump go9 1# lvl_s5vM;
                           1# -> False
                         }
                         }}]
        sumUp1
          = \ (n [Dmd=<S,1*U(U)>] :: Int) ->
              case n of { I# y ->
              case ># 1# y of {
                __DEFAULT ->
                  joinrec {
                    $wgo9 [InlPrag=NOUSERINLINE[2], Occ=LoopBreaker]
                      :: Int# -> Int# -> Bool
                    [LclId[JoinId(2)],
                     Arity=2,
                     Str=<L,U><L,U>,
                     Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True,
                             WorkFree=True, Expandable=True, Guidance=IF_ARGS [0 0] 32 0}]
                    $wgo9 (w_s5za :: Int#) (ww_s5ze :: Int#)
                      = case ==# w_s5za y of {
                          __DEFAULT -> jump $wgo9 (+# w_s5za 1#) (+# ww_s5ze w_s5za);
                          1# -> tagToEnum# @Bool (># (+# ww_s5ze w_s5za) 1000#)
                        }; } in
                  jump $wgo9 1# 0#;
                1# -> False
              }
              }
            
    RHS:    
        sumUp2 [InlPrag=NOUSERINLINE[2]] :: Int -> Bool
        [LclIdX,
         Arity=1,
         Str=<S,1*U(U)>,
         Unf=Unf{Src=InlineStable, TopLvl=True, Value=True, ConLike=True,
                 WorkFree=True, Expandable=True,
                 Guidance=ALWAYS_IF(arity=1,unsat_ok=True,boring_ok=False)
                 Tmpl= \ (w_s5yG [Occ=Once1!] :: Int) ->
                         case w_s5yG of { I# ww_s5yJ [Occ=Once1] -> $wsumUp2 ww_s5yJ }}]
        sumUp2
          = \ (w_s5yG [Dmd=<S,1*U(U)>] :: Int) ->
              case w_s5yG of { I# ww_s5yJ -> $wsumUp2 ww_s5yJ }
            
        $wsumUp2 [InlPrag=NOUSERINLINE[2]] :: Int# -> Bool
        [LclId,
         Arity=1,
         Str=<L,U>,
         Unf=Unf{Src=<vanilla>, TopLvl=True, Value=True, ConLike=True,
                 WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 59 10}]
        $wsumUp2
          = \ (ww_s5yJ :: Int#) ->
              case ># 1# ww_s5yJ of {
                __DEFAULT ->
                  joinrec {
                    $wgo [InlPrag=NOUSERINLINE[2], Occ=LoopBreaker]
                      :: Int# -> Int# -> Bool
                    [LclId[JoinId(2)],
                     Arity=2,
                     Str=<L,U><L,U>,
                     Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True,
                             WorkFree=True, Expandable=True, Guidance=IF_ARGS [0 0] 32 0}]
                    $wgo (ww_s5yz :: Int#) (ww_s5yD :: Int#)
                      = case ==# ww_s5yz ww_s5yJ of {
                          __DEFAULT -> jump $wgo (+# ww_s5yz 1#) (+# ww_s5yD ww_s5yz);
                          1# -> tagToEnum# @Bool (># (+# ww_s5yD ww_s5yz) 1000#)
                        }; } in
                  jump $wgo 1# 0#;
                1# -> False
              }
            
/Users/hiromi/Documents/Programming/Haskell/git/inspection-testing/examples/Fusion.hs:22:1: sumUp1 `hasNoType` GHC.Types.[] passed.
/Users/hiromi/Documents/Programming/Haskell/git/inspection-testing/examples/Fusion.hs:23:1: sumUp1 `hasNoType` GHC.Types.Int failed expectedly.
/Users/hiromi/Documents/Programming/Haskell/git/inspection-testing/examples/Fusion.hs:24:1: sumUp1 does not allocate passed.
/Users/hiromi/Documents/Programming/Haskell/git/inspection-testing/examples/Fusion.hs:25:1: sumUpSort `hasNoType` GHC.Types.[] failed expectedly.
            
examples/Fusion.hs: error:
    inspection testing unsuccessful
          expected successes: 2
           expected failures: 2
         unexpected failures: 1
Progress 1/2

--  While building package inspection-testing-0.4.2.4 (scroll up to its section to see the error) using:
      /Users/hiromi/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_3.4.0.0_ghc-9.0.0.20201227 --builddir=.stack-work/dist/x86_64-osx/Cabal-3.4.0.0 build lib:inspection-testing test:fusion --ghc-options " -fdiagnostics-color=always"
```
</details>

Since I'm not confident that this breakage must be admitted or fixed, I left test cases unchanged.

I couldn't build `more-test`s, as `profunctors` and `generic-lens-core` failed to compile due to the Simplified Subsumptions introduced in GHC 9.
These issues had already been fixed in GitHub HEAD of `profunctors`, but it seems `generic-lens-core` haven't addressed yet. So I gave up to build additional tests.
