### PR TITLE
Ignore unsafe coercions on ghc-9+

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210214
+# version: 0.12.1
 #
-# REGENDATA ("0.11.20210214",["github","inspection-testing.cabal","--no-cabal-check","--last-in-series"])
+# REGENDATA ("0.12.1",["github","inspection-testing.cabal","--no-cabal-check","--last-in-series"])
 #
 name: Haskell-CI
 on:
@@ -18,25 +18,27 @@ on:
   - pull_request
 jobs:
   linux:
-    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:xenial
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - ghc: 8.10.3
+          - compiler: ghc-9.0.1
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-8.10.4
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-8.8.4
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-8.6.5
             allow-failure: false
-          - ghc: 8.2.2
+          - compiler: ghc-8.4.4
             allow-failure: false
-          - ghc: 8.0.2
+          - compiler: ghc-8.2.2
+            allow-failure: false
+          - compiler: ghc-8.0.2
             allow-failure: false
       fail-fast: false
     steps:
@@ -46,29 +48,31 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2
+          apt-get install -y $CC cabal-install-3.4
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          CC: ${{ matrix.compiler }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
           echo "LANG=C.UTF-8" >> $GITHUB_ENV
           echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
+          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
+          HCNAME=ghc
+          HC=$HCDIR/bin/$HCNAME
           echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.2/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
+          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
+          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
           echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
+          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          CC: ${{ matrix.compiler }}
       - name: env
         run: |
           env
@@ -147,9 +151,9 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all

--- a/examples/UnsafeCoerce.hs
+++ b/examples/UnsafeCoerce.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+module UnsafeCoerce (main) where
+
+import Test.Inspection
+import Unsafe.Coerce
+import GHC.Exts
+
+lhs :: Any -> Any
+lhs a = unsafeCoerce $ unsafeCoerce a + (1 :: Int)
+
+rhs :: Int -> Int
+rhs = (+ 1)
+
+inspect $ 'lhs =/= 'rhs
+inspect $ 'lhs ==- 'rhs
+
+main :: IO ()
+main = return ()

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -171,6 +171,17 @@ test-suite worker-wrapper
   if impl(ghc < 8.4)
       ghc-options:       -fplugin=Test.Inspection.Plugin
 
+test-suite unsafe-coerce
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      examples
+  main-is:             UnsafeCoerce.hs
+  build-depends:       inspection-testing
+  build-depends:       base
+  default-language:    Haskell2010
+  ghc-options:         -main-is UnsafeCoerce
+  if impl(ghc < 8.4)
+      ghc-options:       -fplugin=Test.Inspection.Plugin
+
 flag more-tests
   description: Run tests that pull in specific versions of other packages
   default: False

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -155,6 +155,9 @@ eqSlice it slice1 slice2
     essentiallyVar (App e a)  | it, isTyCoArg a = essentiallyVar e
     essentiallyVar (Lam v e)  | it, isTyCoVar v = essentiallyVar e
     essentiallyVar (Cast e _) | it              = essentiallyVar e
+#if MIN_VERSION_ghc(9,0,0)
+    essentiallyVar (Case s _ _ [(_, _, e)]) | it, isUnsafeEqualityProof s = essentiallyVar e
+#endif
     essentiallyVar (Var v)                      = Just v
     essentiallyVar (Tick HpcTick{} e) | it      = essentiallyVar e
     essentiallyVar _                            = Nothing
@@ -168,6 +171,10 @@ eqSlice it slice1 slice2
 
     go env (Cast e1 _) e2 | it             = go env e1 e2
     go env e1 (Cast e2 _) | it             = go env e1 e2
+#if MIN_VERSION_ghc(9,0,0)
+    go env (Case s _ _ [(_, _, e1)]) e2 | it, isUnsafeEqualityProof s = go env e1 e2
+    go env e1 (Case s _ _ [(_, _, e2)]) | it, isUnsafeEqualityProof s = go env e1 e2
+#endif
     go env (Cast e1 co1) (Cast e2 co2)     = do guard (eqCoercionX env co1 co2)
                                                 go env e1 e2
 


### PR DESCRIPTION
Since ghc-9 `unsafeCoerce x` compiles to ``case unsafeEqualityProof of UnsafeRefl co -> x `cast` co`` instead of ``x `cast` co`` older versions produced. Such case would be turned into `x` by CoreToStg, so I suppose that `==-` should treat those expressions as equal. 

This PR changes `eqSlice` to treat `case unsafeEqualityProof of ... -> e` as `e` when 'ignore types' option is on.