### PR TITLE
Move indentation out of pprSliceDifference

### DIFF
--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -93,8 +93,8 @@ pprSlice slice =
 -- | Pretty-print two slices, after removing variables occurring in both
 pprSliceDifference :: Slice -> Slice -> SDoc
 pprSliceDifference slice1 slice2 =
-    nest 4 (hang (text "LHS" Outputable.<> colon) 4 (pprSlice slice1')) $$
-    nest 4 (hang (text "RHS" Outputable.<> colon) 4 (pprSlice slice2'))
+    hang (text "LHS" Outputable.<> colon) 4 (pprSlice slice1') $$
+    hang (text "RHS" Outputable.<> colon) 4 (pprSlice slice2')
   where
     both = S.intersection (S.fromList (map fst slice1)) (S.fromList (map fst slice2))
     slice1' = filter (\(v,_) -> v `S.notMember` both) slice1

--- a/src/Test/Inspection/Plugin.hs
+++ b/src/Test/Inspection/Plugin.hs
@@ -215,7 +215,7 @@ checkProperty guts thn1 (EqualTo thn2 ignore_types) = do
           -- OK if they have the same expression
           then pure ResSuccess
           -- Not ok if the expression differ
-          else pure . ResFailure $ pprSliceDifference slice1 slice2
+          else pure . ResFailure $ nest 4 $ pprSliceDifference slice1 slice2
        -- Not ok if both names are bound externally
        | Nothing <- p1
        , Nothing <- p2

--- a/src/Test/Inspection/Plugin.hs
+++ b/src/Test/Inspection/Plugin.hs
@@ -215,7 +215,7 @@ checkProperty guts thn1 (EqualTo thn2 ignore_types) = do
           -- OK if they have the same expression
           then pure ResSuccess
           -- Not ok if the expression differ
-          else pure . ResFailure $ nest 4 $ pprSliceDifference slice1 slice2
+          else pure . ResFailure $ pprSliceDifference slice1 slice2
        -- Not ok if both names are bound externally
        | Nothing <- p1
        , Nothing <- p2


### PR DESCRIPTION
Otherwise when there is enough indentation coming from other sources, I need to un-indent awkwardly, like `nest (-4) $ pprSliceDifference slice1 slice2`.