### PR TITLE
Generate test cases for text fusion deterministically

### DIFF
--- a/examples/text-api/MoreTextTH.hs
+++ b/examples/text-api/MoreTextTH.hs
@@ -31,7 +31,7 @@ randomPipeline = do
 
 -- Random in the sense of https://xkcd.com/221/
 randomPipelines :: Int -> [[Name]]
-randomPipelines n = unGen
+randomPipelines n = map head $ group $ sort $ unGen
   (vectorOf n randomPipeline)
   (mkQCGen 42) -- seed for QuickCheck generator
   30           -- size for QuickCheck generator

--- a/examples/text-api/text-api.cabal
+++ b/examples/text-api/text-api.cabal
@@ -22,12 +22,12 @@ executable test-strict
                        ShouldDoes
                        TextFuns
   other-extensions:    TemplateHaskell, MagicHash
-  build-depends:       base >=4.11 && <4.12
+  build-depends:       base >=4.11 && <4.17
   build-depends:       inspection-testing >=0.3 && <0.5
-  build-depends:       text ==1.2.3.1
-  build-depends:       QuickCheck >=2.9 && <2.10
-  build-depends:       template-haskell >=2.13 && <2.14
-  build-depends:       bytestring >=0.10 && <0.11
+  build-depends:       text
+  build-depends:       QuickCheck >=2.9 && <2.15
+  build-depends:       template-haskell >=2.13 && <2.19
+  build-depends:       bytestring >=0.10 && <0.12
   default-language:    Haskell2010
   -- -O2 is too slow
   ghc-options:         -O
@@ -43,12 +43,12 @@ executable test-lazy
                        ShouldDoes
                        LazyTextFuns
   other-extensions:    TemplateHaskell, MagicHash
-  build-depends:       base >=4.11 && <4.12
+  build-depends:       base >=4.11 && <4.17
   build-depends:       inspection-testing >=0.3 && <0.5
-  build-depends:       text ==1.2.3.1
-  build-depends:       QuickCheck >=2.9 && <2.10
-  build-depends:       template-haskell >=2.13 && <2.14
-  build-depends:       bytestring >=0.10 && <0.11
+  build-depends:       text
+  build-depends:       QuickCheck >=2.9 && <2.15
+  build-depends:       template-haskell >=2.13 && <2.19
+  build-depends:       bytestring >=0.10 && <0.12
   default-language:    Haskell2010
   -- -O2 is too slow
   ghc-options:         -O
@@ -61,8 +61,8 @@ executable stats
   other-modules:       ShouldDoes
                        TextFuns
                        LazyTextFuns
-  build-depends:       base >=4.11 && <4.12
-  build-depends:       text ==1.2.3.1
-  build-depends:       template-haskell >=2.13 && <2.14
-  build-depends:       bytestring >=0.10 && <0.11
+  build-depends:       base >=4.11 && <4.17
+  build-depends:       text
+  build-depends:       template-haskell >=2.13 && <2.19
+  build-depends:       bytestring >=0.10 && <0.12
   default-language:    Haskell2010


### PR DESCRIPTION
I'm working on utf16-to-utf8 transition in `text`, and `inspection-testing` is extremely helpful to investigate fusion issues. However, I'd like to have a deterministic output between runs, for a fixed QuickCheck seed, otherwise it becomes difficult to compare. 