### PR TITLE
Allow to reorder bindings in lets

### DIFF
--- a/examples/LetsTest.hs
+++ b/examples/LetsTest.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -dsuppress-all #-}
+module Main (main) where
+
+import Test.Inspection
+import Data.Char (toUpper)
+import System.Exit
+
+lhs1, rhs1 :: Char -> Char -> String
+
+lhs1 x y = let x' = toUpper x
+               y' = toUpper y
+           in [x', x', y', y']
+
+rhs1 x y = let y' = toUpper y
+               x' = toUpper x
+           in [x', x', y', y']
+
+-- recursive
+lhs2, rhs2, rhs2b :: String
+lhs2 = let zs = 'z' : xs
+           xs = 'x' : ys
+           ys = 'y' : xs
+       in zs
+
+rhs2 = let ys = 'y' : xs
+           xs = 'x' : ys
+           zs = 'z' : xs
+       in zs
+
+rhs2b = let ys = 'y' : xs
+            xs = 'x' : ys
+            zs = 'z' : ys
+        in zs
+
+printResult :: Result -> IO ()
+printResult (Success s) = putStrLn s
+printResult (Failure s) = putStrLn s
+
+isSuccess :: Result -> Bool
+isSuccess (Success _) = True
+isSuccess (Failure _) = False
+
+results :: [Result]
+results =
+    [ $(inspectTest $ 'lhs1 ==~ 'rhs1)
+    , $(inspectTest $ 'lhs2 ==- 'rhs2) -- here GHC orders let bindings by itself!
+    , $(inspectTest $ 'lhs2 =/~ 'rhs2b)
+    ]
+
+main :: IO ()
+main = do
+    mapM_ printResult results
+    if map isSuccess results == [True, True, False]
+    then exitSuccess
+    else exitFailure

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -1,5 +1,5 @@
 name:                inspection-testing
-version:             0.4.6.1
+version:             0.5
 synopsis:            GHC plugin to do inspection testing
 description:         Some carefully crafted libraries make promises to their
                      users beyond functionality and performance.
@@ -91,6 +91,16 @@ test-suite simple-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      examples
   main-is:             SimpleTest.hs
+  build-depends:       inspection-testing
+  build-depends:       base
+  default-language:    Haskell2010
+  if impl(ghc < 8.4)
+      ghc-options:       -fplugin=Test.Inspection.Plugin
+
+test-suite lets-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      examples
+  main-is:             LetsTest.hs
   build-depends:       inspection-testing
   build-depends:       base
   default-language:    Haskell2010

--- a/src/Test/Inspection.hs
+++ b/src/Test/Inspection.hs
@@ -26,7 +26,8 @@ module Test.Inspection (
     Obligation(..), mkObligation, Equivalence (..), Property(..),
     -- * Convenience functions
     -- $convenience
-    (===), (==-), (=/=), (=/-), hasNoType, hasNoGenerics,
+    (===), (==-), (=/=), (=/-), (==~), (=/~),
+    hasNoType, hasNoGenerics,
     hasNoTypeClasses, hasNoTypeClassesExcept,
     doesNotUse, coreOf,
 ) where
@@ -136,6 +137,7 @@ data Property
 data Equivalence
     = StrictEquiv               -- ^ strict term equality
     | IgnoreTypesAndTicksEquiv  -- ^ ignore types and hpc ticks during the comparison
+    | UnorderedLetsEquiv        -- ^ allow permuted let bindings, ignore types and hpc tick during comparison
     deriving Data
 
 -- | Creates an inspection obligation for the given function name
@@ -167,6 +169,12 @@ infix 9 ===
 (==-) = mkEquality False IgnoreTypesAndTicksEquiv
 infix 9 ==-
 
+-- | Declare two functions to be equal as @('==-')@ but also ignoring
+-- let bindings ordering (see 'EqualTo').
+(==~) :: Name -> Name -> Obligation
+(==~) = mkEquality False UnorderedLetsEquiv
+infix 9 ==~
+
 -- | Declare two functions to be equal, but expect the test to fail (see 'EqualTo' and 'expectFail')
 -- (This is useful for documentation purposes, or as a TODO list.)
 (=/=) :: Name -> Name -> Obligation
@@ -178,6 +186,12 @@ infix 9 =/=
 (=/-) :: Name -> Name -> Obligation
 (=/-) = mkEquality False IgnoreTypesAndTicksEquiv
 infix 9 =/-
+
+-- | Declare two functions to be equal up to let binding ordering (see '(==~)'),
+-- but expect the test to fail (see 'expectFail'),
+(=/~) :: Name -> Name -> Obligation
+(=/~) = mkEquality False UnorderedLetsEquiv
+infix 9 =/~
 
 mkEquality :: Bool -> Equivalence -> Name -> Name -> Obligation
 mkEquality expectFail ignore_types n1 n2 =

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -22,6 +22,7 @@ import GHC.Types.Id
 import GHC.Types.Name
 import GHC.Types.Literal
 import GHC.Types.Var.Env
+import GHC.Types.Unique
 import GHC.Utils.Outputable as Outputable
 import GHC.Core.Ppr
 import GHC.Core.Subst
@@ -45,6 +46,7 @@ import PprCore
 import Coercion
 import Util
 import DataCon
+import Unique
 import TyCon (TyCon, isClassTyCon)
 #endif
 
@@ -54,13 +56,17 @@ import GHC.Types.Tickish
 
 import qualified Data.Set as S
 import Control.Monad.State.Strict
-import Data.List (nub)
+import Data.List (nub, intercalate)
 import Data.Maybe
 
 import Test.Inspection (Equivalence (..))
 
+-- Uncomment to enable debug traces
 -- import Debug.Trace
--- import Data.Bifunctor (bimap)
+
+tracePut :: Monad m => Int -> String -> String -> m ()
+-- tracePut lv name msg = traceM $ replicate lv ' ' ++ name ++ ": " ++ msg
+tracePut _  _    _ = return ()
 
 #if !MIN_VERSION_ghc(9,2,0)
 pattern Alt :: a -> b -> c -> (a, b, c)
@@ -185,6 +191,14 @@ eqSlice eqv slice1 slice2
     it = case eqv of
         StrictEquiv              -> False
         IgnoreTypesAndTicksEquiv -> True
+        UnorderedLetsEquiv       -> True
+
+    -- unordered lets
+    ul :: Bool
+    ul = case eqv of
+        StrictEquiv              -> False
+        IgnoreTypesAndTicksEquiv -> False
+        UnorderedLetsEquiv       -> True
 
     -- results. If there are no pairs to be equated, all is fine.
     results :: [((), VarPairSet)]
@@ -204,9 +218,8 @@ eqSlice eqv slice1 slice2
 
     loop' :: RnEnv2 -> VarPairSet -> Var -> Var -> StateT VarPairSet [] ()
     loop' env done x y = do
-        -- let varToString = occNameString . occName
-        -- traceM $ "x, y = " ++ varToString x ++ ", " ++ varToString y
-        -- traceM $ "done = " ++ show (map (bimap varToString varToString) (S.toList done))
+        tracePut 0 "TOP" (varToString x ++ " =?= " ++ varToString y)
+        tracePut 0 "DONESET" (showVarPairSet done)
 
         -- if x or y expressions are essentially a variable x' or y' respectively
         -- add an obligation to check x' = y (or x = y').
@@ -231,16 +244,14 @@ eqSlice eqv slice1 slice2
                let env' = rnBndr2 env x y
                    done' = S.insert (x, y) done
 
-               go env' e1 e2
+               go 0 env' e1 e2
                loop env' done'
 
             -- and finally, if x or y are not in the slice, we abort.
            | otherwise
-           -> mzero
-
-    equated :: Var -> Var -> StateT VarPairSet [] ()
-    equated x y | x == y = return ()
-    equated x y = modify (S.insert (x,y))
+           -> do
+              tracePut 0 "TOP" (varToString x ++ " =?= " ++ varToString y ++ " NOT IN SLICES")
+              mzero
 
     essentiallyVar :: CoreExpr -> Maybe Var
     essentiallyVar (App e a)  | it, isTyCoArg a = essentiallyVar e
@@ -253,64 +264,91 @@ eqSlice eqv slice1 slice2
     essentiallyVar (Tick HpcTick{} e) | it      = essentiallyVar e
     essentiallyVar _                            = Nothing
 
-    go :: RnEnv2 -> CoreExpr -> CoreExpr -> StateT VarPairSet [] ()
-    go env (Var v1) (Var v2) | rnOccL env v1 == rnOccR env v2 = pure ()
-                             | otherwise                      = equated v1 v2
-    go _   (Lit lit1)    (Lit lit2)        = guard $ lit1 == lit2
-    go env (Type t1)     (Type t2)         = guard $ eqTypeX env t1 t2
-    go env (Coercion co1) (Coercion co2)   = guard $ eqCoercionX env co1 co2
+    go :: Int -> RnEnv2 -> CoreExpr -> CoreExpr -> StateT VarPairSet [] ()
+    go lv env (Var v1) (Var v2) = do
+        if | v1 == v2 -> do
+            tracePut lv "VAR" (varToString v1 ++ " =?= " ++ varToString v2 ++ " SAME")
+            return ()
+           | rnOccL env v1 == rnOccR env v2 -> do
+            tracePut lv "VAR" (varToString v1 ++ " =?= " ++ varToString v2 ++ " IN ENV")
+            return ()
+           | otherwise -> do
+            tracePut lv "VAR" (varToString v1 ++ " =?= " ++ varToString v2 ++ " OBLIGATION")
+            modify (S.insert (v1, v2))
 
-    go env (Cast e1 _) e2 | it             = go env e1 e2
-    go env e1 (Cast e2 _) | it             = go env e1 e2
+    go lv _   (Lit lit1)    (Lit lit2)        = do
+        tracePut lv "LIT" "???" -- no Show for Literal :(
+        guard $ lit1 == lit2
+
+    go _  env (Type t1)     (Type t2)         = guard $ eqTypeX env t1 t2
+    go _  env (Coercion co1) (Coercion co2)   = guard $ eqCoercionX env co1 co2
+
+    go lv env (Cast e1 _) e2 | it             = go lv env e1 e2
+    go lv env e1 (Cast e2 _) | it             = go lv env e1 e2
 #if MIN_VERSION_ghc(9,0,0)
-    go env (Case s _ _ [Alt _ _ e1]) e2 | it, isUnsafeEqualityProof s = go env e1 e2
-    go env e1 (Case s _ _ [Alt _ _ e2]) | it, isUnsafeEqualityProof s = go env e1 e2
+    go lv env (Case s _ _ [Alt _ _ e1]) e2 | it, isUnsafeEqualityProof s = go lv env e1 e2
+    go lv env e1 (Case s _ _ [Alt _ _ e2]) | it, isUnsafeEqualityProof s = go lv env e1 e2
 #endif
-    go env (Cast e1 co1) (Cast e2 co2)     = do guard (eqCoercionX env co1 co2)
-                                                go env e1 e2
+    go lv env (Cast e1 co1) (Cast e2 co2)     = traceBlock lv "CAST" "" $ \lv -> do
+                                                   guard (eqCoercionX env co1 co2)
+                                                   go lv env e1 e2
 
-    go env (App e1 a) e2 | it, isTyCoArg a = go env e1 e2
-    go env e1 (App e2 a) | it, isTyCoArg a = go env e1 e2
-    go env (App f1 a1)   (App f2 a2)       = go env f1 f2 >> go env a1 a2
-    go env (Tick HpcTick{} e1) e2 | it     = go env e1 e2
-    go env e1 (Tick HpcTick{} e2) | it     = go env e1 e2
-    go env (Tick n1 e1)  (Tick n2 e2)      = guard (go_tick env n1 n2) >> go env e1 e2
+    go lv env (App e1 a) e2 | it, isTyCoArg a = go lv env e1 e2
+    go lv env e1 (App e2 a) | it, isTyCoArg a = go lv env e1 e2
+    go lv env (App f1 a1)   (App f2 a2)       = traceBlock lv "APP" "" $ \lv -> do
+                                                   go lv env f1 f2
+                                                   go lv env a1 a2
+    go lv env (Tick HpcTick{} e1) e2 | it     = go lv env e1 e2
+    go lv env e1 (Tick HpcTick{} e2) | it     = go lv env e1 e2
+    go lv env (Tick n1 e1)  (Tick n2 e2)      = traceBlock lv "TICK" "" $ \lv -> do
+                                                   guard (go_tick env n1 n2)
+                                                   go lv env e1 e2
 
-    go env (Lam b e1) e2 | it, isTyCoVar b = go env e1 e2
-    go env e1 (Lam b e2) | it, isTyCoVar b = go env e1 e2
-    go env (Lam b1 e1)  (Lam b2 e2)
-      = do guard (it || eqTypeX env (varType b1) (varType b2))
-                -- False for Id/TyVar combination
-           go (rnBndr2 env b1 b2) e1 e2
+    go lv env (Lam b e1) e2 | it, isTyCoVar b = go lv env e1 e2
+    go lv env e1 (Lam b e2) | it, isTyCoVar b = go lv env e1 e2
+    go lv env (Lam b1 e1)  (Lam b2 e2)        = traceBlock lv "LAM" (varToString b1 ++ " ~ " ++ varToString b2) $ \lv -> do
+           guard (it || eqTypeX env (varType b1) (varType b2))
+           go lv (rnBndr2 env b1 b2) e1 e2
 
-    go env (Let (NonRec v1 r1) e1) (Let (NonRec v2 r2) e2)
-      = do go env r1 r2  -- No need to check binder types, since RHSs match
-           go (rnBndr2 env v1 v2) e1 e2
+    go lv env e1@(Let _ _) e2@(Let _ _)
+      | ul
+      , (ps1, e1') <- peelLets e1
+      , (ps2, e2') <- peelLets e2
+      = traceBlock lv "LET" (showVars ps1 ++ " ~ " ++ showVars ps2) $ \lv -> do
+           guard $ equalLength ps1 ps2
+           env' <- goBinds lv env ps1 ps2
+           go lv env' e1' e2'
 
-    go env (Let (Rec ps1) e1) (Let (Rec ps2) e2)
+    go lv env (Let (NonRec v1 r1) e1) (Let (NonRec v2 r2) e2)
+      = do go lv env r1 r2  -- No need to check binder types, since RHSs match
+           go lv (rnBndr2 env v1 v2) e1 e2
+
+    go lv env (Let (Rec ps1) e1) (Let (Rec ps2) e2)
       = do guard $ equalLength ps1 ps2
-           sequence_ $ zipWith (go env') rs1 rs2
-           go env' e1 e2
+           sequence_ $ zipWith (go lv env') rs1 rs2
+           go lv env' e1 e2
       where
         (bs1,rs1) = unzip ps1
         (bs2,rs2) = unzip ps2
         env' = rnBndrs2 env bs1 bs2
 
-    go env (Case e1 b1 t1 a1) (Case e2 b2 t2 a2)
+    go lv env (Case e1 b1 t1 a1) (Case e2 b2 t2 a2)
       | null a1   -- See Note [Empty case alternatives] in TrieMap
       = do guard (null a2)
-           go env e1 e2
+           go lv env e1 e2
            guard (it || eqTypeX env t1 t2)
       | otherwise
       = do guard $ equalLength a1 a2
-           go env e1 e2
-           sequence_ $ zipWith (go_alt (rnBndr2 env b1 b2)) a1 a2
+           go lv env e1 e2
+           sequence_ $ zipWith (go_alt lv (rnBndr2 env b1 b2)) a1 a2
 
-    go _ _ _ = guard False
+    go lv _ e1 e2 = do
+        tracePut lv "FAIL" (conToString e1 ++ " =/= " ++ conToString e2)
+        mzero
 
     -----------
-    go_alt env (Alt c1 bs1 e1) (Alt c2 bs2 e2)
-      = guard (c1 == c2) >> go (rnBndrs2 env bs1 bs2) e1 e2
+    go_alt lv env (Alt c1 bs1 e1) (Alt c2 bs2 e2)
+      = guard (c1 == c2) >> go lv (rnBndrs2 env bs1 bs2) e1 e2
 
 #if MIN_VERSION_ghc(9,2,0)
     go_tick :: RnEnv2 -> CoreTickish -> CoreTickish -> Bool
@@ -322,7 +360,67 @@ eqSlice eqv slice1 slice2
           = lid == rid  &&  map (rnOccL env) lids == map (rnOccR env) rids
     go_tick _ l r = l == r
 
+    peelLets (Let (NonRec v r) e) = let (xs, e') = peelLets e in ((v,r):xs, e')
+    peelLets (Let (Rec bs) e)     = let (xs, e') = peelLets e in (bs ++ xs, e')
+    peelLets e                    = ([], e)
 
+    goBinds :: Int -> RnEnv2 -> [(Var, CoreExpr)] -> [(Var, CoreExpr)] -> StateT VarPairSet [] RnEnv2
+    goBinds _  env []           []    = return env
+    goBinds _  _   []           (_:_) = mzero
+    goBinds lv env ((v1,b1):xs) ys'   = do
+        -- select a binding
+        ((v2,b2), ys) <- lift (choices ys')
+
+        traceBlock lv "LET*" (varToString v1 ++ " =?= " ++ varToString v2) $ \lv ->
+            go lv env b1 b2
+
+        -- if match succeeds, delete it from the obligations
+        modify (S.delete (v1, v2))
+        -- continue with the rest of bindings, adding a pair as matching one.
+        goBinds lv (rnBndr2 env v1 v2) xs ys
+
+
+traceBlock :: Monad m => Int -> String -> String -> (Int -> m ()) -> m ()
+traceBlock lv name msg action = do
+    tracePut lv name msg
+    action (lv + 1)
+    tracePut lv name $ msg ++ " OK"
+
+showVars :: [(Var, a)] -> String
+showVars xs = intercalate ", " [ varToString x | (x, _) <- xs ]
+
+showVarPairSet :: VarPairSet -> String
+showVarPairSet xs = intercalate ", " [ varToString x ++ " ~ " ++ varToString y | (x, y) <- S.toList xs ]
+
+varToString :: Var -> String
+varToString v = occNameString (occName (tyVarName v)) ++ "_" ++ show (getUnique v)
+-- using tyVarName as varName is ambiguous.
+
+conToString :: CoreExpr -> [Char]
+conToString Var {}      = "Var"
+conToString Lit {}      = "Lit"
+conToString App {}      = "App"
+conToString Lam {}      = "Lam"
+conToString Let {}      = "Let"
+conToString Case {}     = "Case"
+conToString Cast {}     = "Cast"
+conToString Tick {}     = "Tick"
+conToString Type {}     = "Type"
+conToString Coercion {} = "Coercion"
+
+-- |
+--
+-- >>> choices ""
+-- []
+--
+-- >>> choices "abcde"
+-- [('a',"bcde"),('b',"acde"),('c',"abde"),('d',"abce"),('e',"abcd")]
+--
+choices :: [a] -> [(a, [a])]
+choices = go id where
+    go :: ([a] -> [a]) -> [a] -> [(a, [a])]
+    go _ [] = []
+    go f (x:xs) = (x, f xs) : go (f . (x :)) xs
 
 -- | Returns @True@ if the given core expression mentions no type constructor
 -- anywhere that has the given name.

--- a/src/Test/Inspection/Plugin.hs
+++ b/src/Test/Inspection/Plugin.hs
@@ -116,6 +116,7 @@ prettyProperty showName target = \case
   where
     showEquiv StrictEquiv              = "==="
     showEquiv IgnoreTypesAndTicksEquiv = "==-"
+    showEquiv UnorderedLetsEquiv       = "==~"
 
 -- | Like show, but omit the module name if it is he current module
 showTHName :: Module -> TH.Name -> String


### PR DESCRIPTION
This is PoC. In proper implementation there would be new operator (e.g. `==~`) to allow equating more things.

The motivation is that `let` bindings of dictionary construction is not very stable.

This implementation depends on `logict`, but I guess a normal list could be used as well. `StateT VarPairT Maybe ()` seems to be more correct order of transformers, and this PR generalises `Maybe` to list.

Similar logic can be used with `case` branches (but I haven't seen problems with that).

EDIT: this doesn't yet work perfectly, as it records top-level bindings to be matched.