### PR TITLE
Fix bounds for GHC 9.10

### DIFF
--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -45,7 +45,7 @@ library
                        Test.Inspection.Plugin
                        Test.Inspection.Core
   hs-source-dirs:      src
-  build-depends:       base >=4.9 && <4.22
+  build-depends:       base >=4.9 && <4.21
   build-depends:       ghc >= 8.0.2 && <9.11
   build-depends:       template-haskell
   build-depends:       containers


### PR DESCRIPTION
Fixes the base bounds that I incorrectly changed to allow 4.21 in #78 
#78 does add 9.10 CI so I think this PR makes sense rather than a revert PR
