### PR TITLE
Ignore SourceNote tick

### DIFF
--- a/examples/DWARF.hs
+++ b/examples/DWARF.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -g #-}
+module DWARF (main) where
+
+import Test.Inspection
+import Data.Maybe
+
+lhs :: (a -> b) -> Maybe a -> Bool
+lhs f x = isNothing (fmap f x)
+
+rhs :: (a -> b) -> Maybe a -> Bool
+rhs f Nothing = True
+rhs f (Just _) = False
+
+inspect $ 'lhs === 'rhs
+
+main :: IO ()
+main = return ()

--- a/inspection-testing.cabal
+++ b/inspection-testing.cabal
@@ -232,3 +232,13 @@ test-suite text
   if impl(ghc < 8.4)
       ghc-options:       -fplugin=Test.Inspection.Plugin
 
+test-suite dwarf
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      examples
+  main-is:             DWARF.hs
+  build-depends:       inspection-testing
+  build-depends:       base
+  default-language:    Haskell2010
+  ghc-options:         -main-is DWARF
+  if impl(ghc < 8.4)
+      ghc-options:       -fplugin=Test.Inspection.Plugin

--- a/src/Test/Inspection/Core.hs
+++ b/src/Test/Inspection/Core.hs
@@ -272,6 +272,7 @@ eqSlice eqv slice1@((head1, _) : _) slice2@((head2, _) : _)
 #endif
     essentiallyVar (Var v)                      = Just v
     essentiallyVar (Tick HpcTick{} e) | it      = essentiallyVar e
+    essentiallyVar (Tick SourceNote{} e)        = essentiallyVar e
     essentiallyVar _                            = Nothing
 
     go :: Int -> RnEnv2 -> CoreExpr -> CoreExpr -> StateT VarPairSet [] ()
@@ -310,6 +311,8 @@ eqSlice eqv slice1@((head1, _) : _) slice2@((head2, _) : _)
                                                    go lv env a1 a2
     go lv env (Tick HpcTick{} e1) e2 | it     = go lv env e1 e2
     go lv env e1 (Tick HpcTick{} e2) | it     = go lv env e1 e2
+    go lv env (Tick SourceNote{} e1) e2       = go lv env e1 e2
+    go lv env e1 (Tick SourceNote{} e2)       = go lv env e1 e2
     go lv env (Tick n1 e1)  (Tick n2 e2)      = traceBlock lv "TICK" "" $ \lv -> do
                                                    guard (go_tick env n1 n2)
                                                    go lv env e1 e2


### PR DESCRIPTION
When DWARF debugging is enabled in GHC (by the `-g` flag or the `--enable-debug-info` flag in Cabal), GHC seems to produce a `SourceNote` tick in Core that includes the source location and hence fails the equality check. IIUC we should ignore this tick.