### PR TITLE
Fix =/~ and =/-; these were synonymous to ==~ and ==-

### DIFF
--- a/src/Test/Inspection.hs
+++ b/src/Test/Inspection.hs
@@ -212,7 +212,7 @@ infix 9 =/=
 --
 -- @since 0.4.3.0
 (=/-) :: Name -> Name -> Obligation
-(=/-) = mkEquality False IgnoreTypesAndTicksEquiv
+(=/-) = mkEquality True IgnoreTypesAndTicksEquiv
 infix 9 =/-
 
 -- | Declare two functions to be equal up to let binding ordering (see '(==~)'),
@@ -220,7 +220,7 @@ infix 9 =/-
 --
 -- @since 0.5
 (=/~) :: Name -> Name -> Obligation
-(=/~) = mkEquality False UnorderedLetsEquiv
+(=/~) = mkEquality True UnorderedLetsEquiv
 infix 9 =/~
 
 mkEquality :: Bool -> Equivalence -> Name -> Name -> Obligation


### PR DESCRIPTION
Relevant diff and context:

```diff
 (==~) :: Name -> Name -> Obligation
 (==~) = mkEquality False UnorderedLetsEquiv

 (=/=) :: Name -> Name -> Obligation
 (=/=) = mkEquality True StrictEquiv

 (=/~) :: Name -> Name -> Obligation
-(=/~) = mkEquality False UnorderedLetsEquiv
+(=/~) = mkEquality True UnorderedLetsEquiv
```

Previously =/~ was defined the same as ==~. I wonder how this got unnoticed.